### PR TITLE
Add: 작성자(Author) 식별자 및 DTO를 이용해서 일정 조회(전체) 코드 수정

### DIFF
--- a/schedulerapp.sql
+++ b/schedulerapp.sql
@@ -20,19 +20,9 @@ CREATE TABLE authors (
 );
 
 
-/*
-   schedules 테이블에 author_id 컬럼 추가
-   외래 키(Foreign Key)를 author_id 컬럼으로 선언 > id 컬럼 참조
-   authors > id 행 삭제 시 schedules id 참조 데이터가 있을 경우 삭제 X
-   authors > id 값 변경 시 schedules id 값도 자동 업데이트
- */
+# 컬럼 추가(NULL 허용)
 ALTER TABLE schedules
-    ADD COLUMN author_id BIGINT NOT NULL COMMENT '작성자 식별자' AFTER task,
-    ADD CONSTRAINT FK_schedule_author
-        FOREIGN KEY (author_id) REFERENCES authors(id)
-        ON DELETE RESTRICT
-        ON UPDATE CASCADE;
-
+    ADD COLUMN author_id BIGINT NULL COMMENT '작성자 식별자' AFTER task;
 
 /*
    authors >  name, created_date, modified_date 컬럼에 신규 데이터 삽입
@@ -49,4 +39,22 @@ FROM schedules;
  */
 UPDATE schedules s
 JOIN authors a ON s.authorName = a.name
-SET s.author_id = a.id;
+SET s.author_id = a.id
+WHERE s.author_id IS NULL;
+
+/*
+   schedules > author_id 컬럼을 NOT NULL 로 변경
+   외래 키(Foreign Key)를 author_id 컬럼으로 선언 > id 컬럼 참조
+   authors > id 행 삭제 시 schedules id 참조 데이터가 있을 경우 삭제 X
+   authors > id 값 변경 시 schedules id 값도 자동 업데이트
+ */
+ALTER TABLE schedules
+    MODIFY author_id BIGINT NOT NULL COMMENT '작성자 식별자' AFTER task,
+    ADD CONSTRAINT FK_schedule_author
+        FOREIGN KEY (author_id) REFERENCES authors(id)
+        ON DELETE RESTRICT
+        ON UPDATE CASCADE;
+
+
+
+

--- a/src/main/java/com/example/schedulerapp/dto/AuthorRequestDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/AuthorRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.schedulerapp.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AuthorRequestDto {
+
+    private String name;
+    private String email;
+}

--- a/src/main/java/com/example/schedulerapp/dto/AuthorResponseDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/AuthorResponseDto.java
@@ -1,0 +1,25 @@
+package com.example.schedulerapp.dto;
+
+import com.example.schedulerapp.entity.Author;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class AuthorResponseDto {
+
+    private Long id;
+    private String name;
+    private String email;
+    private LocalDate createdDate;
+    private LocalDate modifiedDate;
+
+    public AuthorResponseDto(Author author) {
+        this.id = author.getId();
+        this.name = author.getName();
+        this.email = author.getEmail();
+        this.createdDate = author.getCreatedDate();
+        this.modifiedDate = author.getModifiedDate();
+    }
+
+}

--- a/src/main/java/com/example/schedulerapp/dto/AuthorResponseDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/AuthorResponseDto.java
@@ -1,11 +1,13 @@
 package com.example.schedulerapp.dto;
 
 import com.example.schedulerapp.entity.Author;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDate;
 
 @Getter
+@AllArgsConstructor
 public class AuthorResponseDto {
 
     private Long id;

--- a/src/main/java/com/example/schedulerapp/dto/ScheduleRequestDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/ScheduleRequestDto.java
@@ -10,6 +10,9 @@ import lombok.Getter;
 public class ScheduleRequestDto {
 
     private String task;
+    private Long authorId;
     private String authorName;
     private String password;
+
+
 }

--- a/src/main/java/com/example/schedulerapp/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/ScheduleResponseDto.java
@@ -12,6 +12,7 @@ public class ScheduleResponseDto {
 
     private long id;
     private String task;
+    private AuthorResponseDto author;
     private String authorName;
     private LocalDate createdDate;
     private LocalDate modifiedDate;
@@ -20,6 +21,14 @@ public class ScheduleResponseDto {
         this.id = schedule.getId();
         this.task = schedule.getTask();
         this.authorName = schedule.getAuthorName();
+        this.createdDate = schedule.getCreatedDate();
+        this.modifiedDate = schedule.getModifiedDate();
+    }
+
+    public ScheduleResponseDto (Schedule schedule, AuthorResponseDto author) {
+        this.id = schedule.getId();
+        this.task = schedule.getTask();
+        this.author = author;
         this.createdDate = schedule.getCreatedDate();
         this.modifiedDate = schedule.getModifiedDate();
     }

--- a/src/main/java/com/example/schedulerapp/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/ScheduleResponseDto.java
@@ -32,4 +32,20 @@ public class ScheduleResponseDto {
         this.createdDate = schedule.getCreatedDate();
         this.modifiedDate = schedule.getModifiedDate();
     }
+
+    public ScheduleResponseDto (Long id, String task, String authorName, LocalDate createdDate, LocalDate modifiedDate) {
+        this.id = id;
+        this.task = task;
+        this.authorName = authorName;
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
+    }
+
+    public ScheduleResponseDto (Long id, String task, AuthorResponseDto author, LocalDate createdDate, LocalDate modifiedDate) {
+        this.id = id;
+        this.task = task;
+        this.author = author;
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
+    }
 }

--- a/src/main/java/com/example/schedulerapp/entity/Author.java
+++ b/src/main/java/com/example/schedulerapp/entity/Author.java
@@ -1,0 +1,15 @@
+package com.example.schedulerapp.entity;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class Author {
+
+    private Long id;
+    private String name;
+    private String email;
+    private LocalDate createdDate;
+    private LocalDate modifiedDate;
+}

--- a/src/main/java/com/example/schedulerapp/entity/Schedule.java
+++ b/src/main/java/com/example/schedulerapp/entity/Schedule.java
@@ -36,6 +36,15 @@ public class Schedule {
         this.modifiedDate = testCreatedDate;
     }
 
+    public Schedule(Long id, String task, String authorName, String password, LocalDate createdDate, LocalDate modifiedDate) {
+        this.id = id;
+        this.task = task;
+        this.authorName = authorName;
+        this.password = password;
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
+    }
+
     public void updateSchedule(String task, String authorName) {
         this.task = task;
         this.authorName = authorName;

--- a/src/main/java/com/example/schedulerapp/entity/Schedule.java
+++ b/src/main/java/com/example/schedulerapp/entity/Schedule.java
@@ -11,6 +11,7 @@ public class Schedule {
 
     private Long id;
     private String task;
+    private Long authorId;
     private String authorName;
     private String password;
     private LocalDate createdDate;


### PR DESCRIPTION
da8c09d9a48e2b389c30a1bb8d9b95a349eaa612
- (Fix) (SQL) author_id 컬럼 추가 시 NOT NULL 로 할 경우 발생하는 오류에 대한 해결
 > schedules 테이블에 author_id 컬럼 추가 > NULL 설정
 > INSERT INTO, UPDATE 쿼리문 진행
 > 이후 schedules 테이블 구조 변경
 > author_id NOT NULL 설정 && FK 선언

17b7166b2713ef8416a99c96370c10d5bb53d335
- (Add) Author Entity 생성

5d813625a5cb1aee7675d64359d0abf83c63f6c4
- (Add) Author Request/Response DTO 생성

7de582960450fe77f0255a3648716dad5632aecb
- 기존 Schedule Entity, DTO 에 author Id(작성자 식별자) 추가

26270ae815436a758aeaedbf026270827e392c15
- (Add) ScheduleResponseDto
 > AuthorResponseDto 를 매개변수로 가진 생성자 생성

- (Add) ScheduleRepositoryJdbc
 > 일정 조회(전체) 메서드인 findAllSchedules 에서 작성자(Author) 식별자(id)를 활용한 (SQL)JOIN 을 활용 > schedules 테이블의 컬럼 + author 테이블을 컬럼이 조회되도록 구현
 >  기존 scheduleRowMapper 에 AuthorResponseDto 를 활용한 별도의 매퍼(scheduleRowMapperWithAuthorDto)를 구현하여 활용 > RowMapper 역할 분리 목적

- (Update)Schedule / ScheduleResponseDto
 >  기존 구현된 코드에 해당 클래스들의 생성자를 활용한 코드를 계속 이용하기 위해 기존 속성들을 가진 생성자 생성