### PR TITLE
Add: 페이지네이션이 적용된 일정 조회(전체) 기능 구현

### DIFF
--- a/src/main/java/com/example/schedulerapp/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulerapp/controller/ScheduleController.java
@@ -1,11 +1,13 @@
 package com.example.schedulerapp.controller;
 
+import com.example.schedulerapp.dto.PageResponseDto;
 import com.example.schedulerapp.dto.ScheduleRequestDto;
 import com.example.schedulerapp.dto.ScheduleResponseDto;
 import com.example.schedulerapp.service.ScheduleService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.*;
 
@@ -53,6 +55,19 @@ public class ScheduleController {
 
         return new ResponseEntity<>(scheduleService.findAllSchedules(), HttpStatus.OK);
     }
+
+    @GetMapping("/pagination")
+    public ResponseEntity<PageResponseDto<ScheduleResponseDto>> findSchedulesPagination(
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "5") int size
+    ) {
+        if (page < 0  || size <0){
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Page and size must be positive values.");
+        }
+
+        return new ResponseEntity<>(scheduleService.findSchedulesPagination(page, size), HttpStatus.OK);
+    }
+
 
     /**
      * 저장된 일정 조회(단건) 기능

--- a/src/main/java/com/example/schedulerapp/dto/PageResponseDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/PageResponseDto.java
@@ -1,0 +1,26 @@
+package com.example.schedulerapp.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 페이지네이션 처리된 결과를 보여주는 DTO
+ * - schedules: 페이지에 저장된 일정
+ * - page: 페이지 번호
+ * - size: 페이지 크기
+ * - totalSchedules: 전체 일정 수
+ * - totalPages: 전체 페이지 수
+ */
+
+@Getter
+@AllArgsConstructor
+public class PageResponseDto<T> {
+
+    private List<T> schedules;
+    private Integer page;
+    private Integer size;
+    private Long totalSchedules;
+    private Integer totalPages;
+}

--- a/src/main/java/com/example/schedulerapp/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/schedulerapp/repository/ScheduleRepository.java
@@ -11,6 +11,9 @@ public interface ScheduleRepository {
 
     List<ScheduleResponseDto> findAllSchedules();
 
+    List<ScheduleResponseDto> findSchedulesPagination(Integer offset, Integer limit);
+    Long countSchedules();
+
     Schedule findScheduleByIDOrElseThrow(Long id);
 
     int updateTaskOrAuthorName(Long id, String task, String authorName, String password);

--- a/src/main/java/com/example/schedulerapp/repository/ScheduleRepositoryJdbc.java
+++ b/src/main/java/com/example/schedulerapp/repository/ScheduleRepositoryJdbc.java
@@ -72,6 +72,32 @@ public class ScheduleRepositoryJdbc implements ScheduleRepository{
     }
 
     @Override
+    public List<ScheduleResponseDto> findSchedulesPagination(Integer offset, Integer limit) {
+        return jdbcTemplate.query
+                ("SELECT " +
+                                " s.id," +
+                                " s.task," +
+                                " s.created_date," +
+                                " s.modified_date," +
+                                " a.id AS author_id," +
+                                " a.name AS author_name," +
+                                " a.email AS author_email," +
+                                " a.created_date AS author_created_date," +
+                                " a.modified_date AS author_modified_date " +
+                                " FROM schedules s JOIN authors a ON a.id = s.author_id " +
+                                " LIMIT ? OFFSET ?",
+                        scheduleRowMapperWithAuthorDto(), limit, offset
+                );
+    }
+
+    @Override
+    public Long countSchedules() {
+        return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM schedules", Long.class);
+    }
+
+
+
+    @Override
     public int updateTaskOrAuthorName(Long id, String task, String authorName, String password) {
         return jdbcTemplate.update("UPDATE schedules set task = ?, authorName = ?, modified_date = ? where id = ? AND password = ?", task, authorName, LocalDate.now(), id, password);
     }

--- a/src/main/java/com/example/schedulerapp/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulerapp/service/ScheduleService.java
@@ -1,5 +1,6 @@
 package com.example.schedulerapp.service;
 
+import com.example.schedulerapp.dto.PageResponseDto;
 import com.example.schedulerapp.dto.ScheduleRequestDto;
 import com.example.schedulerapp.dto.ScheduleResponseDto;
 
@@ -10,6 +11,8 @@ public interface ScheduleService {
     ScheduleResponseDto createSchedule(ScheduleRequestDto requestDto);
 
     List<ScheduleResponseDto> findAllSchedules();
+
+    PageResponseDto<ScheduleResponseDto> findSchedulesPagination(Integer page, Integer size);
 
     ScheduleResponseDto findScheduleById(Long id);
 

--- a/src/main/java/com/example/schedulerapp/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/schedulerapp/service/ScheduleServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.schedulerapp.service;
 
+import com.example.schedulerapp.dto.PageResponseDto;
 import com.example.schedulerapp.dto.ScheduleRequestDto;
 import com.example.schedulerapp.dto.ScheduleResponseDto;
 import com.example.schedulerapp.entity.Schedule;
@@ -53,6 +54,16 @@ public class ScheduleServiceImpl implements ScheduleService {
     public List<ScheduleResponseDto> findAllSchedules() {
 
         return scheduleRepository.findAllSchedules();
+    }
+
+    @Override
+    public PageResponseDto<ScheduleResponseDto> findSchedulesPagination(Integer page, Integer size) {
+        Integer offset = (page - 1) * size;
+        List<ScheduleResponseDto> schedules = scheduleRepository.findSchedulesPagination(offset, size);
+        Long total = scheduleRepository.countSchedules();
+        Integer totalPages = (int) Math.ceil((double) total / size);
+
+        return new PageResponseDto<>(schedules, page, size, total, totalPages);
     }
 
     @Override


### PR DESCRIPTION
- 페이지 번호(page), 페이지 크기(size)를 param 값으로 설정하여 조회
 > 시작 지점(offset), 한 번에 가져올 데이터 수(limit) 활용
 > PageResponseDto 를 활용 > 페이지네이션 처리 결과 DTO 추가 활용
- 저장된 데이터 수 이상의 페이지 번호 입력 시 빈 배열로 조회